### PR TITLE
🐛 Fix: 위시리스트 공통 컴포넌트 퍼블리싱(#28)

### DIFF
--- a/src/pages/ConsumptionPage/ConsumptionPage.tsx
+++ b/src/pages/ConsumptionPage/ConsumptionPage.tsx
@@ -38,7 +38,7 @@ const ConsumptionPage = () => {
   }, [currentType]);
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col h-screen">
       <section className="px-[20px] pt-[43px] pb-[26px]">
         <h2 className="text-[18px] leading-[150%] font-semibold mb-[12px]">평균 구매 결정 시간: {stats.avgDays}일</h2>
         <p className="text-gray-600 text-[14px]">
@@ -46,7 +46,7 @@ const ConsumptionPage = () => {
         </p>
       </section>
 
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
         <WishlistPanel editMode={false} bottomPaddingPx={0}>
           <div className="flex-1 overflow-y-auto no-scrollbar pb-[90px]">
             <WishlistGrid items={products} editMode={false} onItemClick={(id) => console.log('상품 클릭:', id)} />

--- a/src/pages/WishlistPage/WishlistPage.tsx
+++ b/src/pages/WishlistPage/WishlistPage.tsx
@@ -214,7 +214,7 @@ export default function WishlistPage() {
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto no-scrollbar">
               <WishlistGrid items={items} editMode selectedIds={selectedItemIds} onToggleSelect={toggleSelectItem} />
-              <div className="h-[96px]" />
+              <div className="h-[50px]" />
             </div>
           </>
         ) : (
@@ -225,7 +225,7 @@ export default function WishlistPage() {
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto no-scrollbar">
               <WishlistGrid items={items} />
-              <div className="h-[96px]" />
+              <div className="h-[50px]" />
             </div>
           </>
         )}

--- a/src/pages/WishlistPage/components/wishlistGrid.tsx
+++ b/src/pages/WishlistPage/components/wishlistGrid.tsx
@@ -26,7 +26,14 @@ export default function WishlistGrid({
 }: Props) {
   return (
     <div className="pb-6">
-      <div className="grid grid-cols-3 gap-x-4 gap-y-6">
+      <div
+        className={[
+          'grid grid-cols-3',
+          'gap-x-[26px] gap-y-[26px]',
+          'w-full',
+          'h-fit',
+        ].join(' ')}
+      >
         {items.map((it) => (
           <WishlistItem
             key={it.id}

--- a/src/pages/WishlistPage/components/wishlistPanel.tsx
+++ b/src/pages/WishlistPage/components/wishlistPanel.tsx
@@ -14,8 +14,8 @@ export default function WishlistPanel({
   return (
     <section
       className={[
-        'flex-1 min-h-0 flex flex-col',
-        
+        'w-full flex-1 mt-[1px] mx-auto', 
+        'flex flex-col',
         editMode ? 'bg-[color:var(--color-gray-100)]' : 'bg-[color:var(--color-secondary-100)]',
         'rounded-t-[20px]',
         'shadow-[0_0_4px_rgba(0,0,0,0.25)]',
@@ -23,7 +23,7 @@ export default function WishlistPanel({
         'relative',
       ].join(' ')}
     >
-      <div className="px-[16px] pt-[16px] flex-1 flex flex-col min-h-0">
+      <div className="flex-1 min-h-0 flex flex-col p-[20px] pb-[16px]">
         {children}
       </div>
       


### PR DESCRIPTION
## 📑 이슈 번호

- close#28

## 🔥 작업 내용

- 공통 컴포넌트 버그 수정하였습니다.

## 💭 코멘트


## 📸 스크린샷 (선택)
<img width="343" height="705" alt="image" src="https://github.com/user-attachments/assets/ef52a320-6744-4f7b-8f88-581fd06c76ac" />
<img width="368" height="753" alt="image" src="https://github.com/user-attachments/assets/5f02f538-772e-494f-8ab7-a261dd6ab7b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 위시리스트 페이지의 하단 여백을 96px에서 50px로 단축하여 수직 공간을 최적화했습니다.
  * 위시리스트 그리드의 간격을 개선하고 너비 및 높이 제약을 추가했습니다.
  * 위시리스트 패널의 패딩과 간격을 조정하여 콘텐츠 배치를 개선했습니다.
  * 소비 페이지의 레이아웃 크기를 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->