### PR TITLE
🐛 Fix: 예산 설정 전송 데이터 0 값 제거

### DIFF
--- a/src/pages/BudgetSettingPage/BudgetSettingPage.tsx
+++ b/src/pages/BudgetSettingPage/BudgetSettingPage.tsx
@@ -23,14 +23,7 @@ const BudgetSettingPage = () => {
 
   const { setCustomBack, setRightAction, setTitle } = useOutletContext<HeaderControlContext>();
 
-  const [budgetData, setBudgetData] = useState<SetBudgetRequest>({
-    monthlyIncome: 0,
-    incomeDate: 0,
-    fixedExpense: 0,
-    monthlySaving: 0,
-    spendStrategy: 0,
-    shoppingBudget: 0,
-  });
+  const [budgetData, setBudgetData] = useState<Partial<SetBudgetRequest>>({});
 
   const updateData = (key: keyof SetBudgetRequest, value: number) => {
     setBudgetData((prev) => ({ ...prev, [key]: value }));
@@ -57,10 +50,6 @@ const BudgetSettingPage = () => {
   }, [step, navigate]);
 
   const nextStep = useCallback(() => {
-    if (step === TOTAL_STEPS) {
-      submitBudget(budgetData);
-      return;
-    }
     setDirection(1);
     setStep((prev) => prev + 1);
   }, [step, budgetData, submitBudget, navigate, TOTAL_STEPS]);
@@ -162,15 +151,21 @@ const BudgetSettingPage = () => {
               <Step6
                 onNext={(val) => {
                   updateData('shoppingBudget', val);
-                  nextStep();
+
+                  const finalData = {
+                    ...budgetData,
+                    shoppingBudget: val,
+                  };
+
+                  const cleanData = Object.fromEntries(
+                    Object.entries(finalData).filter(
+                      ([_, value]) => value !== 0 && value !== undefined && value !== null,
+                    ),
+                  );
+                  submitBudget(cleanData as unknown as SetBudgetRequest);
                 }}
                 defaultValue={budgetData.shoppingBudget}
-                prevData={{
-                  monthlyIncome: budgetData.monthlyIncome,
-                  fixedExpense: budgetData.fixedExpense,
-                  monthlySaving: budgetData.monthlySaving,
-                  spendStrategy: budgetData.spendStrategy,
-                }}
+                prevData={budgetData}
               />
             )}
           </motion.div>

--- a/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
+++ b/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
@@ -73,7 +73,11 @@ const StrategyCard = ({ isEdit, data, onChange }: StrategyCardProps) => {
                   value={data.shoppingTarget ? Number(data.shoppingTarget).toLocaleString() : ''}
                   placeholder="0"
                   onChange={handleTargetChange}
-                  className={`${inputStyle} w-[104px] ${showWarning ? 'border-red-500 shake-animation' : 'border-gray-600 focus:border-primary-brown-400'}`}
+                  style={{
+                    width: `${Math.max(data.shoppingTarget ? Number(data.shoppingTarget).toLocaleString().length : 1, 1) + 2}ch`,
+                    minWidth: '60px',
+                  }}
+                  className={`${inputStyle} w-auto ${showWarning ? 'border-red-500 shake-animation' : 'border-gray-600 focus:border-primary-brown-400'}`}
                 />
 
                 {showWarning && (


### PR DESCRIPTION
## 📑 이슈 번호

- close #

## 🔥 작업 내용

- 예산 설정 전송 데이터 0 값 제거
- 자산 형성 전략 선택 후 스탭6 페이지에서 표시
- 예산 설정 결과 페이지 수정 인풋 박스 동적 크기 제어

## 💭 코멘트

- 

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예산 설정 마지막 단계에서 선택된 전략에 따른 동적 제목 표시
  * 쇼핑 목표 입력 필드가 입력값 길이에 따라 자동으로 너비 조정

* **개선사항**
  * 예산 데이터 제출 프로세스 개선으로 더 안정적인 데이터 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->