### PR TITLE
Fix: 예산 설정 페이지 값이 없을 시 0 값 표시

### DIFF
--- a/src/pages/BudgetSummaryPage/components/InfoItem.tsx
+++ b/src/pages/BudgetSummaryPage/components/InfoItem.tsx
@@ -9,7 +9,8 @@ interface InfoItemProps {
 }
 
 const InfoItem = ({ label, value, isEdit, onChange, icon }: InfoItemProps) => {
-  const isZero = value === 0;
+  const safeValue = Number(value) || 0;
+  const isZero = safeValue === 0;
 
   return (
     <div className="w-full">
@@ -32,7 +33,7 @@ const InfoItem = ({ label, value, isEdit, onChange, icon }: InfoItemProps) => {
             <span className="text-[14px] text-gray-600">{label}</span>
             <span className={`text-[20px] font-semibold ${isZero ? 'text-primary-brown-400' : 'text-primary-600'}`}>
               {!isZero && '+ '}
-              {value.toLocaleString()}
+              {safeValue.toLocaleString()}
             </span>
           </div>
         </div>

--- a/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
+++ b/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
@@ -107,7 +107,7 @@ const StrategyCard = ({ isEdit, data, onChange }: StrategyCardProps) => {
                 className={`${inputStyle} w-[60px] border-gray-600 focus:border-primary-brown-400`}
               />
             ) : (
-              <span>{data.renewalDay}</span>
+              <span>{data.renewalDay || '0'}</span>
             )}
             <span>일</span>
           </div>

--- a/src/pages/HomePage/components/ReviewList.tsx
+++ b/src/pages/HomePage/components/ReviewList.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { motion } from 'framer-motion';
 import ArrowIcon from '@/assets/arrow.svg?react';
 
 interface ReviewItem {
@@ -13,17 +12,18 @@ interface ReviewItem {
 const getDDay = (dateString: string) => {
   const today = new Date();
   const purchaseDate = new Date(dateString);
-  const diffTime = Math.abs(today.getTime() - purchaseDate.getTime());
-  return `${Math.floor(diffTime / (1000 * 60 * 60 * 24))} Day+`;
+
+  today.setHours(0, 0, 0, 0);
+  purchaseDate.setHours(0, 0, 0, 0);
+
+  const diffTime = today.getTime() - purchaseDate.getTime();
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays <= 0) return 'Today';
+  return `${diffDays} Day+`;
 };
 
-export const ReviewList = ({
-  items,
-  scrollRef,
-}: {
-  items?: ReviewItem[];
-  scrollRef: React.RefObject<HTMLDivElement | null>;
-}) => (
+export const ReviewList = ({ items }: { items?: ReviewItem[]; scrollRef: React.RefObject<HTMLDivElement | null> }) => (
   <div className="mb-[100px]">
     {/* 타이틀 */}
     <div className="flex justify-between items-center mb-[14px] ">
@@ -32,30 +32,26 @@ export const ReviewList = ({
     </div>
 
     {/* 가로 스크롤 카드 리스트 */}
-    <div ref={scrollRef} className="overflow-hidden -mx-[20px]">
-      <motion.div
-        className="flex gap-4 w-max px-[20px]"
-        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-        drag="x"
-        dragConstraints={scrollRef}>
-        {items?.map((item) => (
-          <div key={item.itemId} className="flex flex-col min-w-[94px] gap-[6px] cursor-pointer">
-            <span className="text-gray-600 text-[12px] mb-[2px] leading-none font-medium">
-              {getDDay(item.purchasedAt)}
-            </span>
-
-            <div className={`w-[94px] h-[94px] rounded-[5px] overflow-hidden`}>
-              {item.imageUrl && <img src={item.imageUrl} alt={item.itemName} className="w-full h-full object-cover" />}
-            </div>
-
-            {/* 가격 및 이름 */}
-            <div className="flex flex-col gap-[6px] px-[2px] ">
-              <span className="text-[12px] leading-none font-medium">{item.price.toLocaleString()}원</span>
-              <span className="text-[12px] leading-none truncate w-[94px]">{item.itemName}</span>
-            </div>
+    <div
+      className="flex gap-4 overflow-x-auto overflow-y-hidden -mx-[20px] px-[20px] 
+                 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      style={{ WebkitOverflowScrolling: 'touch' }}>
+      {items?.map((item) => (
+        <div key={item.itemId} className="flex flex-col min-w-[94px] gap-[6px] cursor-pointer select-none">
+          <span className="text-gray-600 text-[12px] mb-[2px] leading-none font-medium">
+            {getDDay(item.purchasedAt)}
+          </span>
+          <div className="w-[94px] h-[94px] rounded-[5px] overflow-hidden bg-gray-100">
+            {item.imageUrl && (
+              <img src={item.imageUrl} alt={item.itemName} className="w-full h-full object-cover" draggable={false} />
+            )}
           </div>
-        ))}
-      </motion.div>
+          <div className="flex flex-col gap-[6px] px-[2px]">
+            <span className="text-[12px] leading-none font-medium">{(item.price ?? 0).toLocaleString()}원</span>
+            <span className="text-[12px] leading-none truncate w-[94px]">{item.itemName}</span>
+          </div>
+        </div>
+      ))}
     </div>
   </div>
 );


### PR DESCRIPTION
## 📑 이슈 번호

- close#

## 🔥 작업 내용

- Fix: 예산 설정 페이지 값이 없을 시 0 값 표시
- Design: 소비 후기 리스트 가로 드래그 수정

## 💭 코멘트

- 코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요.

## 📸 스크린샷 (선택)
