### PR TITLE
🐛 Fix : 비밀번호 모바일에서 깨지는 문제 해결

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -125,10 +125,6 @@
   overflow: hidden; */
 }
 
-input[type='password']::-webkit-textfield-decoration-container {
-  display: none !important;
-}
-
 input[type='password']::-ms-reveal {
   display: none !important;
 }


### PR DESCRIPTION
## 📑 이슈 번호

- #73 

## 🔥 작업 내용

- 🐛 Fix : 비밀번호 모바일에서 깨지는 문제 해결

## 💭 코멘트

- 

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * WebKit 브라우저에서 비밀번호 입력 필드의 장식 요소가 정상적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->