### PR TITLE
🐛 Fix: 예산 설정 페이지 자산 형성 전략 하드코딩 제거(#188)

### DIFF
--- a/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
+++ b/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
@@ -66,7 +66,7 @@ const StrategyCard = ({ isEdit, data, onChange }: StrategyCardProps) => {
   return (
     <div className="flex flex-col items-center w-full border-[1.5px] border-primary-500 rounded-[10px] px-[21px] pt-[10px] mb-[24px] bg-primary-100 shadow-[0_0_3px_rgba(0,0,0,0.25)] shadow-primary-500">
       <div className="flex px-[10px] py-[6px] rounded-full text-white text-[12px] bg-primary-600">
-        {strategyNames[data.strategy as number] || '자산 형성'} 전략
+        {strategyNames[data.strategy] || '자산 형성'} 전략
       </div>
       <div className="flex flex-col w-full gap-[10px] my-[29px]">
         {/* 쇼핑 목표액 */}

--- a/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
+++ b/src/pages/BudgetSummaryPage/components/StrategyCard.tsx
@@ -7,6 +7,12 @@ interface StrategyCardProps {
   onChange: (key: keyof BudgetData, value: string) => void;
 }
 
+const strategyNames: Record<number, string> = {
+  1: '자산 형성',
+  2: '균형 지출',
+  3: '자유 지출',
+};
+
 const StrategyCard = ({ isEdit, data, onChange }: StrategyCardProps) => {
   const [showWarning, setShowWarning] = useState(false);
 
@@ -59,7 +65,9 @@ const StrategyCard = ({ isEdit, data, onChange }: StrategyCardProps) => {
 
   return (
     <div className="flex flex-col items-center w-full border-[1.5px] border-primary-500 rounded-[10px] px-[21px] pt-[10px] mb-[24px] bg-primary-100 shadow-[0_0_3px_rgba(0,0,0,0.25)] shadow-primary-500">
-      <div className="flex px-[10px] py-[6px] rounded-full text-white text-[12px] bg-primary-600">자산 형성 전략</div>
+      <div className="flex px-[10px] py-[6px] rounded-full text-white text-[12px] bg-primary-600">
+        {strategyNames[data.strategy as number] || '자산 형성'} 전략
+      </div>
       <div className="flex flex-col w-full gap-[10px] my-[29px]">
         {/* 쇼핑 목표액 */}
         <div className="flex flex-col gap-[2px] relative">


### PR DESCRIPTION
## 📑 이슈 번호

- close #188 

## 🔥 작업 내용

- 작업 내용을 간략히 설명해 주세요.

## 💭 코멘트

- 코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요.

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 전략 레이블이 정적 텍스트에서 전략 유형에 따라 동적으로 표시됩니다. 표시되는 값은 '자산 형성', '균형 지출', '자유 지출' 중 해당 전략명(없을 경우 기본값 '자산 형성')이며, 사용자 화면의 전략 표기 가독성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->